### PR TITLE
Scrap method fix for games that don't have "Supported languages" section

### DIFF
--- a/nintendeals/noa/scrapers/nintendo.py
+++ b/nintendeals/noa/scrapers/nintendo.py
@@ -18,7 +18,11 @@ def scrap(slug):
     data = json.loads(script.text)["props"]["pageProps"]["product"]
 
     h3 = soup.find("h3", text="Supported languages")
-    languages = next(h3.nextSiblingGenerator())
+
+    if h3:
+        languages = next(h3.nextSiblingGenerator())
+    else:
+        languages = None
 
     if languages:
         languages = languages.text.strip().split(", ")

--- a/nintendeals/noa/scrapers/nintendo.py
+++ b/nintendeals/noa/scrapers/nintendo.py
@@ -29,7 +29,12 @@ def scrap(slug):
     else:
         languages = ["English"]
 
-    nso_features = {feature["code"] for feature in data["nsoFeatures"]}
+    features_data = data.get("nsoFeatured", None)
+
+    if features_data:
+        nso_features = {feature["code"] for feature in features_data}
+    else:
+        nso_features = set()
 
     return {
         "nsuid": data.get("nsuid"),


### PR DESCRIPTION
Hello, 

I noticed the `scrap` method failing for this page https://www.nintendo.com/store/products/pokemon-scarlet-the-hidden-treasure-of-area-zero-70070000016943-switch/

Because it doesn't have supported languages listed at all.

> AttributeError: 'NoneType' object has no attribute 'nextSiblingGenerator'

This is just simple check if the `h3` was found.

Let me know if I should change anything.